### PR TITLE
fix: resolve absolute path to file url correctly

### DIFF
--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -1,3 +1,4 @@
+import { isAbsolute } from 'path';
 import { runAsWorker } from 'synckit';
 import { pathToFileURL } from 'url';
 
@@ -16,7 +17,7 @@ runAsWorker(
     text, prettierEslintPath, filePath, extensionConfig,
   }) => {
     const format = /** @type {typeof import('prettier-eslint')} */ (
-      (await import(pathToFileURL(prettierEslintPath))).default
+      (await import(isAbsolute(prettierEslintPath) ? pathToFileURL(prettierEslintPath) : prettierEslintPath)).default
     );
     return format({
       text,

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -1,4 +1,5 @@
 import { runAsWorker } from 'synckit';
+import { pathToFileURL } from 'url';
 
 runAsWorker(
   /**
@@ -15,7 +16,7 @@ runAsWorker(
     text, prettierEslintPath, filePath, extensionConfig,
   }) => {
     const format = /** @type {typeof import('prettier-eslint')} */ (
-      (await import(prettierEslintPath)).default
+      (await import(pathToFileURL(prettierEslintPath))).default
     );
     return format({
       text,


### PR DESCRIPTION
This change ensures absolute file path to be resolved correctly as File URL on Windows.

Fixes issue raised by me [here](https://github.com/idahogurl/vs-code-prettier-eslint/issues/171#issuecomment-1892347013)

NodeJS references:
[File URLs](https://nodejs.org/docs/latest-v16.x/api/esm.html#file-urls)
[url.pathToFileURL](https://nodejs.org/docs/latest-v16.x/api/url.html#url_url_pathtofileurl_path)