### PR TITLE
Fix TypeError

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -102,10 +102,10 @@ function waitForActiveSupportedDocument() {
     || !supportedLanguages.includes(window.activeTextEditor.document.languageId)
   ) {
     return new Promise((resolve) => {
-      const handler = window.onDidChangeActiveTextEditor(({ document }) => {
-        if (supportedLanguages.includes(document.languageId)) {
+      const handler = window.onDidChangeActiveTextEditor((editor) => {
+        if (editor && supportedLanguages.includes(editor.document.languageId)) {
           handler.dispose();
-          resolve(document);
+          resolve(editor.document);
         }
       });
     });


### PR DESCRIPTION
This fixes the following error:
```
Extension 'rvest.vs-code-prettier-eslint' FAILED to handle event: TypeError: Cannot destructure property 'document' of 'undefined' as it is undefined.
```